### PR TITLE
Add local conversation model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,21 @@ AI villagers also have one of these randomly selected personalities:
 
 ## Configuration
 
-To configure this plugin you will need an OpenAI API key and, optionally, GPT-4 access. You can obtain an API key [here](https://platform.openai.com/). Once you have obtained one, place it in the plugin's `config.yml` under `openai-key`.
+The plugin can operate in two modes controlled by the `provider` option in `config.yml`.
+When set to `openai`, an OpenAI API key is required. Obtain one [here](https://platform.openai.com/) and place it under `openai-key` in the config.
+If `provider` is set to `local`, VillagerGPT will POST the current conversation to the URL defined by `local-model-url` and use the response as the villager's reply.
 
 ### GPT-4
 
 If you have GPT-4 access, it is highly recommended you switch the model in the config to use GPT-4 instead of the default model. GPT-4 is significantly better at listening to the `system` message and thus following instructions.
 
 You can switch to GPT-4 by replacing `openai-model` in `config.yml` with `gpt-4`.
+
+### Local Model
+
+Set `provider` to `local` to use a locally hosted language model. Configure the
+endpoint with `local-model-url`. The plugin will send the conversation as plain
+text and expects the response body to contain the villager's reply.
 
 ## Commands
 

--- a/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
@@ -11,6 +11,7 @@ import tj.horner.villagergpt.conversation.pipeline.MessageProcessorPipeline
 import tj.horner.villagergpt.conversation.pipeline.processors.ActionProcessor
 import tj.horner.villagergpt.conversation.pipeline.processors.TradeOfferProcessor
 import tj.horner.villagergpt.conversation.pipeline.producers.OpenAIMessageProducer
+import tj.horner.villagergpt.conversation.pipeline.producers.LocalMessageProducer
 import tj.horner.villagergpt.handlers.ConversationEventsHandler
 import tj.horner.villagergpt.tasks.EndStaleConversationsTask
 import java.util.logging.Level
@@ -18,7 +19,7 @@ import java.util.logging.Level
 class VillagerGPT : SuspendingJavaPlugin() {
     val conversationManager = VillagerConversationManager(this)
     val messagePipeline = MessageProcessorPipeline(
-        OpenAIMessageProducer(config),
+        createMessageProducer(),
         listOf(
             ActionProcessor(),
             TradeOfferProcessor(logger)
@@ -29,7 +30,7 @@ class VillagerGPT : SuspendingJavaPlugin() {
         saveDefaultConfig()
 
         if (!validateConfig()) {
-            logger.log(Level.WARNING, "VillagerGPT has not been configured correctly! Please set the `openai-key` in config.yml.")
+            logger.log(Level.WARNING, "VillagerGPT has not been configured correctly! Please check your configuration values.")
             return
         }
 
@@ -58,7 +59,18 @@ class VillagerGPT : SuspendingJavaPlugin() {
     }
 
     private fun validateConfig(): Boolean {
-        val openAiKey = config.getString("openai-key") ?: return false
-        return openAiKey.trim() != ""
+        val provider = config.getString("provider") ?: "openai"
+        return if (provider.equals("local", ignoreCase = true)) {
+            val url = config.getString("local-model-url") ?: return false
+            url.trim().isNotEmpty()
+        } else {
+            val openAiKey = config.getString("openai-key") ?: return false
+            openAiKey.trim().isNotEmpty()
+        }
+    }
+
+    private fun createMessageProducer() = when (config.getString("provider")?.lowercase()) {
+        "local" -> LocalMessageProducer(config)
+        else -> OpenAIMessageProducer(config)
     }
 }

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
@@ -1,0 +1,21 @@
+package tj.horner.villagergpt.conversation.pipeline.producers
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.apache.Apache
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import org.bukkit.configuration.Configuration
+import tj.horner.villagergpt.conversation.VillagerConversation
+import tj.horner.villagergpt.conversation.pipeline.ConversationMessageProducer
+
+class LocalMessageProducer(config: Configuration) : ConversationMessageProducer {
+    private val client = HttpClient(Apache)
+    private val endpoint = config.getString("local-model-url") ?: "http://localhost:8000/"
+
+    override suspend fun produceNextMessage(conversation: VillagerConversation): String {
+        val payload = conversation.messages.joinToString("\n") { "${'$'}{it.role}: ${'$'}{it.content}" }
+        val response = client.post(endpoint) { setBody(payload) }
+        return response.bodyAsText()
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,9 +1,15 @@
+# Use "openai" to talk to the OpenAI API or "local" to use a locally hosted model.
+provider: "openai"
+
 # Obtain a key here: https://platform.openai.com
 openai-key: ""
 
 # If you have GPT-4 access, it is highly recommended to use it here.
 # Switch this to "gpt-4" if you do.
 openai-model: "gpt-3.5-turbo"
+
+# URL for your locally hosted model's endpoint.
+local-model-url: "http://localhost:8000/"
 
 # Log conversation messages to server console, useful for catching abuse
 log-conversations: true


### PR DESCRIPTION
## Summary
- support local message producer to connect to a locally hosted model
- allow choosing `provider` via config and specify local endpoint
- instantiate `LocalMessageProducer` when configured
- document configuration for local models

## Testing
- `./gradlew build` *(fails: Unsupported class file major version)*

------
https://chatgpt.com/codex/tasks/task_e_68611b7041c8832cbc7a30389d855be7