### PR TITLE
Add conversation memory using SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ If you have GPT-4 access, it is highly recommended you switch the model in the c
 
 You can switch to GPT-4 by replacing `openai-model` in `config.yml` with `gpt-4`.
 
+### Conversation Memory
+
+VillagerGPT keeps a history of each villager's conversations in a small SQLite
+database. The location of this database and how many messages are stored can be
+changed in `config.yml` under the `memory` section.
+
 ## Commands
 
 - `/ttv`: Initiate a conversation with a villager

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation platform("com.aallam.openai:openai-client-bom:3.2.1")
     implementation "com.aallam.openai:openai-client"
     implementation "io.ktor:ktor-client-apache"
+    implementation "org.xerial:sqlite-jdbc:3.45.3.0"
 }
 
 def targetJavaVersion = 17

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
@@ -21,6 +21,9 @@ class VillagerConversation(private val plugin: Plugin, val villager: Villager, v
     var ended = false
 
     init {
+        if (plugin is tj.horner.villagergpt.VillagerGPT && plugin::memory.isInitialized) {
+            messages.addAll(plugin.memory.loadMessages(villager))
+        }
         startConversation()
     }
 

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
@@ -60,6 +60,9 @@ class VillagerConversationManager(private val plugin: Plugin) {
     private fun endConversations(conversationsToEnd: Collection<VillagerConversation>) {
         conversationsToEnd.forEach {
             it.ended = true
+            if (plugin is tj.horner.villagergpt.VillagerGPT && plugin::memory.isInitialized) {
+                plugin.memory.saveMessages(it.villager, it.messages)
+            }
             val endEvent = VillagerConversationEndEvent(it.player, it.villager)
             plugin.server.pluginManager.callEvent(endEvent)
         }

--- a/src/main/kotlin/tj/horner/villagergpt/memory/MemoryManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/memory/MemoryManager.kt
@@ -1,0 +1,77 @@
+package tj.horner.villagergpt.memory
+
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import org.bukkit.entity.Villager
+import org.bukkit.plugin.Plugin
+import java.io.File
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.util.Base64
+
+class MemoryManager(private val plugin: Plugin) {
+    private val connection: Connection
+    private val maxMessages: Int
+
+    init {
+        val path = plugin.config.getString("memory.db-path") ?: "memory.db"
+        val dbFile = if (File(path).isAbsolute) File(path) else File(plugin.dataFolder, path)
+        dbFile.parentFile.mkdirs()
+        connection = DriverManager.getConnection("jdbc:sqlite:${dbFile.path}")
+        connection.createStatement().use { stmt ->
+            stmt.executeUpdate(
+                "CREATE TABLE IF NOT EXISTS memory (villager_uuid TEXT PRIMARY KEY, messages TEXT)"
+            )
+        }
+        maxMessages = plugin.config.getInt("memory.max-messages", 20)
+    }
+
+    fun loadMessages(villager: Villager): MutableList<ChatMessage> {
+        val stmt: PreparedStatement = connection.prepareStatement("SELECT messages FROM memory WHERE villager_uuid = ?")
+        stmt.setString(1, villager.uniqueId.toString())
+        val rs = stmt.executeQuery()
+        val result = if (rs.next()) {
+            val data = rs.getString("messages") ?: ""
+            deserializeMessages(data)
+        } else {
+            mutableListOf()
+        }
+        rs.close()
+        stmt.close()
+        return result
+    }
+
+    fun saveMessages(villager: Villager, messages: List<ChatMessage>) {
+        val trimmed = messages.takeLast(maxMessages)
+        val data = serializeMessages(trimmed)
+        val stmt: PreparedStatement = connection.prepareStatement(
+            "INSERT OR REPLACE INTO memory(villager_uuid, messages) VALUES (?, ?)"
+        )
+        stmt.setString(1, villager.uniqueId.toString())
+        stmt.setString(2, data)
+        stmt.executeUpdate()
+        stmt.close()
+    }
+
+    fun close() {
+        connection.close()
+    }
+
+    private fun serializeMessages(messages: List<ChatMessage>): String {
+        return messages.joinToString("\n") { msg ->
+            val encoded = Base64.getEncoder().encodeToString(msg.content.toByteArray(Charsets.UTF_8))
+            "${msg.role.role}=$encoded"
+        }
+    }
+
+    private fun deserializeMessages(data: String): MutableList<ChatMessage> {
+        if (data.isBlank()) return mutableListOf()
+        return data.split("\n").map { line ->
+            val parts = line.split("=", limit = 2)
+            val role = ChatRole(parts[0])
+            val content = String(Base64.getDecoder().decode(parts[1]), Charsets.UTF_8)
+            ChatMessage(role = role, content = content)
+        }.toMutableList()
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,3 +11,10 @@ log-conversations: true
 # Either "system" or "user"; configures the type of message the "preamble"
 # will be. "user" is more likely to work with GPT-3.5
 preamble-message-type: user
+
+# Conversation memory settings
+memory:
+  # Path to SQLite database file. Relative paths are relative to the plugin data folder
+  db-path: memory.db
+  # Maximum number of messages to remember per villager
+  max-messages: 20


### PR DESCRIPTION
## Summary
- add new `MemoryManager` module with SQLite
- load and save conversation messages when conversations start or end
- expose memory settings in `config.yml`
- document memory usage in `README`
- include `sqlite-jdbc` dependency

## Testing
- `./gradlew build -x test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68611efb1804832ca833fbc4eff0e538