### PR TITLE
Add persistent conversation memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Set `provider` to `local` to use a locally hosted language model. Configure the
 endpoint with `local-model-url`. The plugin will send the conversation as plain
 text and expects the response body to contain the villager's reply.
 
+### Memory
+
+VillagerGPT can remember past conversations. The plugin stores messages in a
+SQLite database whose location is configured with `database-path`. You can also
+limit how many messages are kept per villager with `max-stored-messages`.
+
 ## Commands
 
 - `/ttv`: Initiate a conversation with a villager

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation platform("com.aallam.openai:openai-client-bom:3.2.1")
     implementation "com.aallam.openai:openai-client"
     implementation "io.ktor:ktor-client-apache"
+
+    implementation "org.xerial:sqlite-jdbc:3.42.0.0"
 }
 
 def targetJavaVersion = 17

--- a/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
@@ -12,12 +12,14 @@ import tj.horner.villagergpt.conversation.pipeline.processors.ActionProcessor
 import tj.horner.villagergpt.conversation.pipeline.processors.TradeOfferProcessor
 import tj.horner.villagergpt.conversation.pipeline.producers.OpenAIMessageProducer
 import tj.horner.villagergpt.conversation.pipeline.producers.LocalMessageProducer
+import tj.horner.villagergpt.memory.ConversationMemory
 import tj.horner.villagergpt.handlers.ConversationEventsHandler
 import tj.horner.villagergpt.tasks.EndStaleConversationsTask
 import java.util.logging.Level
 
 class VillagerGPT : SuspendingJavaPlugin() {
     val conversationManager = VillagerConversationManager(this)
+    val memory = ConversationMemory(this)
     val messagePipeline = MessageProcessorPipeline(
         createMessageProducer(),
         listOf(
@@ -42,6 +44,7 @@ class VillagerGPT : SuspendingJavaPlugin() {
     override fun onDisable() {
         logger.info("Ending all conversations")
         conversationManager.endAllConversations()
+        memory.close()
     }
 
     private fun setCommandExecutors() {

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
@@ -6,14 +6,14 @@ import com.aallam.openai.api.chat.ChatRole
 import com.destroystokyo.paper.entity.villager.ReputationType
 import org.bukkit.entity.Player
 import org.bukkit.entity.Villager
-import org.bukkit.plugin.Plugin
+import tj.horner.villagergpt.VillagerGPT
 import tj.horner.villagergpt.events.VillagerConversationMessageEvent
 import java.time.Duration
 import java.util.*
 import kotlin.random.Random
 
 @OptIn(BetaOpenAI::class)
-class VillagerConversation(private val plugin: Plugin, val villager: Villager, val player: Player) {
+class VillagerConversation(private val plugin: VillagerGPT, val villager: Villager, val player: Player) {
     private var lastMessageAt: Date = Date()
 
     val messages = mutableListOf<ChatMessage>()
@@ -22,6 +22,8 @@ class VillagerConversation(private val plugin: Plugin, val villager: Villager, v
 
     init {
         startConversation()
+        val history = plugin.memory.loadMessages(villager.uniqueId)
+        messages.addAll(history)
     }
 
     fun addMessage(message: ChatMessage) {

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
@@ -2,11 +2,13 @@ package tj.horner.villagergpt.conversation
 
 import org.bukkit.entity.Player
 import org.bukkit.entity.Villager
-import org.bukkit.plugin.Plugin
+import com.aallam.openai.api.BetaOpenAI
+import tj.horner.villagergpt.VillagerGPT
 import tj.horner.villagergpt.events.VillagerConversationEndEvent
 import tj.horner.villagergpt.events.VillagerConversationStartEvent
 
-class VillagerConversationManager(private val plugin: Plugin) {
+@OptIn(BetaOpenAI::class)
+class VillagerConversationManager(private val plugin: VillagerGPT) {
     private val conversations: MutableList<VillagerConversation> = mutableListOf()
 
     fun endStaleConversations() {
@@ -59,6 +61,7 @@ class VillagerConversationManager(private val plugin: Plugin) {
 
     private fun endConversations(conversationsToEnd: Collection<VillagerConversation>) {
         conversationsToEnd.forEach {
+            plugin.memory.saveMessages(it.villager.uniqueId, it.messages)
             it.ended = true
             val endEvent = VillagerConversationEndEvent(it.player, it.villager)
             plugin.server.pluginManager.callEvent(endEvent)

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
@@ -6,9 +6,11 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import org.bukkit.configuration.Configuration
+import com.aallam.openai.api.BetaOpenAI
 import tj.horner.villagergpt.conversation.VillagerConversation
 import tj.horner.villagergpt.conversation.pipeline.ConversationMessageProducer
 
+@OptIn(BetaOpenAI::class)
 class LocalMessageProducer(config: Configuration) : ConversationMessageProducer {
     private val client = HttpClient(Apache)
     private val endpoint = config.getString("local-model-url") ?: "http://localhost:8000/"

--- a/src/main/kotlin/tj/horner/villagergpt/memory/ConversationMemory.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/memory/ConversationMemory.kt
@@ -1,0 +1,92 @@
+package tj.horner.villagergpt.memory
+
+import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.chat.ChatMessage
+import com.aallam.openai.api.chat.ChatRole
+import org.bukkit.plugin.Plugin
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.util.Base64
+import java.util.UUID
+
+@OptIn(BetaOpenAI::class)
+class ConversationMemory(plugin: Plugin) {
+    private val connection: Connection
+    private val maxMessages: Int
+
+    init {
+        val dbPath = plugin.config.getString("database-path")
+            ?: "${plugin.dataFolder}/memory.db"
+        maxMessages = plugin.config.getInt("max-stored-messages", 20)
+
+        Class.forName("org.sqlite.JDBC")
+        connection = DriverManager.getConnection("jdbc:sqlite:$dbPath")
+        connection.createStatement().use {
+            it.executeUpdate(
+                "CREATE TABLE IF NOT EXISTS villager_memory (villager_uuid TEXT PRIMARY KEY, messages TEXT)"
+            )
+        }
+    }
+
+    fun loadMessages(uuid: UUID): List<ChatMessage> {
+        val stmt = connection.prepareStatement("SELECT messages FROM villager_memory WHERE villager_uuid = ?")
+        stmt.use {
+            it.setString(1, uuid.toString())
+            val rs = it.executeQuery()
+            if (rs.next()) {
+                val data = rs.getString("messages") ?: return emptyList()
+                val messages = decodeMessages(data)
+                return limitMessages(messages)
+            }
+        }
+        return emptyList()
+    }
+
+    fun saveMessages(uuid: UUID, messages: List<ChatMessage>) {
+        val filtered = limitMessages(messages.filter { it.role != ChatRole.System })
+        val data = encodeMessages(filtered)
+        val stmt: PreparedStatement = connection.prepareStatement(
+            "INSERT INTO villager_memory(villager_uuid, messages) VALUES (?, ?) ON CONFLICT(villager_uuid) DO UPDATE SET messages = excluded.messages"
+        )
+        stmt.use {
+            it.setString(1, uuid.toString())
+            it.setString(2, data)
+            it.executeUpdate()
+        }
+    }
+
+    fun close() {
+        connection.close()
+    }
+
+    private fun limitMessages(messages: List<ChatMessage>): List<ChatMessage> {
+        if (maxMessages <= 0) return messages
+        return if (messages.size <= maxMessages) messages else messages.takeLast(maxMessages)
+    }
+
+    private fun encodeMessages(messages: List<ChatMessage>): String {
+        return messages.joinToString("\n") {
+            val encoded = Base64.getEncoder().encodeToString(it.content.toByteArray())
+            "${it.role}|$encoded"
+        }
+    }
+
+    private fun decodeMessages(data: String): List<ChatMessage> {
+        if (data.isBlank()) return emptyList()
+        return data.lines().mapNotNull { line ->
+            if (line.isBlank()) return@mapNotNull null
+            val parts = line.split("|", limit = 2)
+            if (parts.size != 2) return@mapNotNull null
+            val roleString = parts[0]
+            val role = when(roleString.lowercase()) {
+                "system" -> ChatRole.System
+                "assistant" -> ChatRole.Assistant
+                "user" -> ChatRole.User
+                else -> ChatRole(roleString)
+            }
+            val content = String(Base64.getDecoder().decode(parts[1]))
+            ChatMessage(role = role, content = content)
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,3 +17,9 @@ log-conversations: true
 # Either "system" or "user"; configures the type of message the "preamble"
 # will be. "user" is more likely to work with GPT-3.5
 preamble-message-type: user
+
+# Path to the SQLite database storing villager memories
+database-path: "./plugins/VillagerGPT/memory.db"
+
+# Maximum number of messages to store per villager (0 to disable)
+max-stored-messages: 20


### PR DESCRIPTION
## Summary
- manage conversation history via SQLite
- save memory at the end of conversations
- reload villager history when starting
- configure DB path and size limit
- document usage of memory

## Testing
- `./gradlew compileKotlin --stacktrace`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68611de31c9c832c951f2a4b1a281c4b