### PR TITLE
Add gossip mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ They can perform the following actions in their responses:
 - Propose trades
 - Shake head
 - Play various sounds
+- Recall and share gossip with nearby villagers
 
 Villagers will also react to their surroundings. The plugin watches the
 environment during a conversation and inserts messages when the weather
@@ -72,6 +73,14 @@ You can switch to GPT-4 by replacing `openai-model` in `config.yml` with `gpt-4`
 VillagerGPT keeps a history of each villager's conversations in a small SQLite
 database. The location of this database and how many messages are stored can be
 changed in `config.yml` under the `memory` section.
+
+### Gossip
+
+Villagers remember interesting pieces of gossip. When two villagers stand near
+each other they will exchange a few of these rumors. Gossip is loaded into the
+start of any conversation, giving you insight into what villagers have been
+talking about. Control the sharing radius and how many entries are kept with the
+`gossip` section in `config.yml`.
 
 ### Local Model
 

--- a/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
@@ -16,6 +16,7 @@ import tj.horner.villagergpt.conversation.pipeline.producers.LocalMessageProduce
 import tj.horner.villagergpt.handlers.ConversationEventsHandler
 import tj.horner.villagergpt.tasks.EndStaleConversationsTask
 import tj.horner.villagergpt.tasks.EnvironmentWatcher
+import tj.horner.villagergpt.tasks.GossipManager
 
 import java.util.logging.Level
 
@@ -72,6 +73,7 @@ class VillagerGPT : SuspendingJavaPlugin() {
     private fun scheduleTasks() {
         EndStaleConversationsTask(this).runTaskTimer(this, 0L, 200L)
         EnvironmentWatcher(this).runTaskTimer(this, 0L, 20L)
+        GossipManager(this).runTaskTimer(this, 0L, 200L)
     }
 
     private fun validateConfig(): Boolean {

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
@@ -78,6 +78,13 @@ class VillagerConversation(private val plugin: VillagerGPT, val villager: Villag
 
         val historyLimit = plugin.config.getInt("max-stored-messages", 20)
         messages.addAll(plugin.memory.loadMessages(villager.uniqueId, historyLimit))
+
+        val gossipLimit = plugin.config.getInt("gossip.max-entries", 30)
+        val gossip = plugin.memory.loadGossip(villager.uniqueId, gossipLimit)
+        if (gossip.isNotEmpty()) {
+            val gossipText = gossip.joinToString("\n") { "- $it" }
+            messages.add(ChatMessage(ChatRole.System, "Known gossip:\n$gossipText"))
+        }
     }
 
     private fun generateSystemPrompt(): String {

--- a/src/main/kotlin/tj/horner/villagergpt/tasks/GossipManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/tasks/GossipManager.kt
@@ -1,0 +1,44 @@
+package tj.horner.villagergpt.tasks
+
+import org.bukkit.entity.Villager
+import org.bukkit.scheduler.BukkitRunnable
+import tj.horner.villagergpt.VillagerGPT
+import java.util.UUID
+
+class GossipManager(private val plugin: VillagerGPT) : BukkitRunnable() {
+    private val radius: Double = plugin.config.getDouble("gossip.radius", 10.0)
+    private val radiusSquared = radius * radius
+
+    override fun run() {
+        val gossipLimit = plugin.config.getInt("gossip.max-entries", 30)
+
+        plugin.server.worlds.forEach { world ->
+            val villagers = world.getEntitiesByClass(Villager::class.java)
+            for (i in villagers.indices) {
+                val villagerA = villagers[i]
+                for (j in i + 1 until villagers.size) {
+                    val villagerB = villagers[j]
+                    if (villagerA.location.distanceSquared(villagerB.location) <= radiusSquared) {
+                        shareGossip(villagerA.uniqueId, villagerB.uniqueId, gossipLimit)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun shareGossip(idA: UUID, idB: UUID, limit: Int) {
+        val memory = plugin.memory
+        val gossipA = memory.loadGossip(idA, limit)
+        val gossipB = memory.loadGossip(idB, limit)
+
+        if (gossipA.isEmpty() && gossipB.isEmpty()) return
+
+        val shareCount = 3
+        val toB = gossipA.shuffled().take(shareCount)
+        val toA = gossipB.shuffled().take(shareCount)
+
+        memory.addGossip(idB, toB, limit)
+        memory.addGossip(idA, toA, limit)
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,12 @@ memory:
   # Maximum number of messages to remember per villager
   max-messages: 20
 
+gossip:
+  # Distance in blocks within which villagers will exchange gossip
+  radius: 10
+  # Maximum number of gossip entries stored per villager
+  max-entries: 30
+
 
 # Keep villagers aware during conversations so they can move and react
 # Set to true if you don't want them to freeze in place


### PR DESCRIPTION
## Summary
- extend conversation memory with gossip table and helpers
- add a GossipManager task for sharing rumors
- preload stored gossip when starting a conversation
- allow configuring gossip behaviour in config.yml
- document gossip feature

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68612d11424c832cbaed12f013444863