### PR TITLE
Update memory config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ VillagerGPT keeps a history of each villager's conversations in a small SQLite
 database. The location of this database and how many messages are stored can be
 changed in `config.yml` under the `memory` section.
 
+The maximum messages remembered per villager are configured with the
+`memory.max-messages` option.
+
 ### Gossip
 
 Villagers remember interesting pieces of gossip. When two villagers stand near

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
@@ -76,7 +76,7 @@ class VillagerConversation(private val plugin: VillagerGPT, val villager: Villag
             )
         )
 
-        val historyLimit = plugin.config.getInt("max-stored-messages", 20)
+        val historyLimit = plugin.config.getInt("memory.max-messages", 20)
         messages.addAll(plugin.memory.loadMessages(villager.uniqueId, historyLimit))
 
         val gossipLimit = plugin.config.getInt("gossip.max-entries", 30)

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
@@ -67,7 +67,7 @@ class VillagerConversationManager(private val plugin: VillagerGPT) {
     private fun endConversations(conversationsToEnd: Collection<VillagerConversation>) {
         conversationsToEnd.forEach {
             val history = it.messages.drop(1)
-            plugin.memory.appendMessages(it.villager.uniqueId, history, plugin.config.getInt("max-stored-messages", 20))
+            plugin.memory.appendMessages(it.villager.uniqueId, history, plugin.config.getInt("memory.max-messages", 20))
             it.ended = true
             val endEvent = VillagerConversationEndEvent(it.player, it.villager)
             plugin.server.pluginManager.callEvent(endEvent)


### PR DESCRIPTION
## Summary
- use `memory.max-messages` option in conversation classes
- document `memory.max-messages` in the README

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686131c83988832c8274b8443782dc40