### PR TITLE
Add environment config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ start of any conversation, giving you insight into what villagers have been
 talking about. Control the sharing radius and how many entries are kept with the
 `gossip` section in `config.yml`.
 
+### Environment
+
+VillagerGPT watches the surroundings during conversations. Adjust how far away
+entities are detected using `environment.radius` and how often checks occur with
+`environment.interval` in `config.yml`.
+
 ### Local Model
 
 Set `provider` to `local` to use a locally hosted language model. Configure the

--- a/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
@@ -72,7 +72,8 @@ class VillagerGPT : SuspendingJavaPlugin() {
 
     private fun scheduleTasks() {
         EndStaleConversationsTask(this).runTaskTimer(this, 0L, 200L)
-        EnvironmentWatcher(this).runTaskTimer(this, 0L, 20L)
+        val envInterval = config.getLong("environment.interval", 20L)
+        EnvironmentWatcher(this).runTaskTimer(this, 0L, envInterval)
         GossipManager(this).runTaskTimer(this, 0L, 200L)
     }
 

--- a/src/main/kotlin/tj/horner/villagergpt/tasks/EnvironmentWatcher.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/tasks/EnvironmentWatcher.kt
@@ -18,6 +18,8 @@ class EnvironmentWatcher(private val plugin: VillagerGPT) : BukkitRunnable() {
 
     private val state = mutableMapOf<VillagerConversation, EnvironmentState>()
 
+    private val radius: Double = plugin.config.getDouble("environment.radius", 5.0)
+
     override fun run() {
         val conversations = plugin.conversationManager.getActiveConversations()
         state.keys.retainAll(conversations)
@@ -46,7 +48,6 @@ class EnvironmentWatcher(private val plugin: VillagerGPT) : BukkitRunnable() {
             }
 
             // Nearby entity detection
-            val radius = 5.0
             val nearby: Set<Int> = world.getNearbyEntities(villager.location, radius, radius, radius)
                 .filter { it != villager && it != convo.player }
                 .map(Entity::getEntityId)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,6 +32,13 @@ gossip:
   # Maximum number of gossip entries stored per villager
   max-entries: 30
 
+# Watch the environment during conversations and narrate changes
+environment:
+  # Distance in blocks in which to watch for nearby mobs or players
+  radius: 5
+  # How often to check the environment, in ticks
+  interval: 20
+
 
 # Keep villagers aware during conversations so they can move and react
 # Set to true if you don't want them to freeze in place


### PR DESCRIPTION
## Summary
- allow configuring environment watcher radius and interval
- use radius when scanning for nearby entities
- schedule watcher using configurable interval
- document new configuration options

## Testing
- `./gradlew test` *(fails: Unsupported class file major version)*

------
https://chatgpt.com/codex/tasks/task_e_686131c900b4832c9748241fa2a97bdb