### PR TITLE
Wrap memory operations in IO coroutines

### DIFF
--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversation.kt
@@ -3,6 +3,7 @@ package tj.horner.villagergpt.conversation
 import com.aallam.openai.api.BetaOpenAI
 import com.aallam.openai.api.chat.ChatMessage
 import com.aallam.openai.api.chat.ChatRole
+import kotlinx.coroutines.runBlocking
 import com.destroystokyo.paper.entity.villager.ReputationType
 import org.bukkit.entity.Player
 import org.bukkit.entity.Villager
@@ -77,7 +78,7 @@ class VillagerConversation(private val plugin: VillagerGPT, val villager: Villag
         )
 
         val historyLimit = plugin.config.getInt("max-stored-messages", 20)
-        messages.addAll(plugin.memory.loadMessages(villager.uniqueId, historyLimit))
+        messages.addAll(runBlocking { plugin.memory.loadMessages(villager.uniqueId, historyLimit) })
 
         val gossipLimit = plugin.config.getInt("gossip.max-entries", 30)
         val gossip = plugin.memory.loadGossip(villager.uniqueId, gossipLimit)

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
@@ -3,6 +3,7 @@ package tj.horner.villagergpt.conversation
 import org.bukkit.entity.Player
 import org.bukkit.entity.Villager
 import tj.horner.villagergpt.VillagerGPT
+import kotlinx.coroutines.runBlocking
 import tj.horner.villagergpt.events.VillagerConversationEndEvent
 import tj.horner.villagergpt.events.VillagerConversationStartEvent
 import com.aallam.openai.api.BetaOpenAI
@@ -67,7 +68,9 @@ class VillagerConversationManager(private val plugin: VillagerGPT) {
     private fun endConversations(conversationsToEnd: Collection<VillagerConversation>) {
         conversationsToEnd.forEach {
             val history = it.messages.drop(1)
-            plugin.memory.appendMessages(it.villager.uniqueId, history, plugin.config.getInt("max-stored-messages", 20))
+            runBlocking {
+                plugin.memory.appendMessages(it.villager.uniqueId, history, plugin.config.getInt("max-stored-messages", 20))
+            }
             it.ended = true
             val endEvent = VillagerConversationEndEvent(it.player, it.villager)
             plugin.server.pluginManager.callEvent(endEvent)


### PR DESCRIPTION
## Summary
- handle ConversationMemory DB work on `Dispatchers.IO`
- call new suspend functions from conversation and manager via `runBlocking`

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686131c92008832c9b88de9d99ffcc9f