### PR TITLE
Improve local model reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ talking about. Control the sharing radius and how many entries are kept with the
 ### Local Model
 
 Set `provider` to `local` to use a locally hosted language model. Configure the
-endpoint with `local-model-url`. The plugin will send the conversation as plain
-text and expects the response body to contain the villager's reply.
+endpoint with `local-model-url`. By default the conversation is sent as plain
+text and the response body is used as the villager's reply. Set
+`local-model-json` to `true` if your model expects a JSON payload containing the
+conversation messages.
 
 
 

--- a/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
@@ -88,7 +88,7 @@ class VillagerGPT : SuspendingJavaPlugin() {
     }
 
     private fun createMessageProducer() = when (config.getString("provider")?.lowercase()) {
-        "local" -> LocalMessageProducer(config)
+        "local" -> LocalMessageProducer(this, config)
         else -> OpenAIMessageProducer(config)
     }
 }

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
@@ -5,19 +5,57 @@ import io.ktor.client.engine.apache.Apache
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.bukkit.configuration.Configuration
+import tj.horner.villagergpt.VillagerGPT
+import tj.horner.villagergpt.chat.ChatMessageTemplate
 import tj.horner.villagergpt.conversation.VillagerConversation
 import tj.horner.villagergpt.conversation.pipeline.ConversationMessageProducer
 import com.aallam.openai.api.BetaOpenAI
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+import java.util.logging.Level
 
 @OptIn(BetaOpenAI::class)
-class LocalMessageProducer(config: Configuration) : ConversationMessageProducer {
+class LocalMessageProducer(private val plugin: VillagerGPT, config: Configuration) : ConversationMessageProducer {
     private val client = HttpClient(Apache)
     private val endpoint = config.getString("local-model-url") ?: "http://localhost:8000/"
+    private val sendJson = config.getBoolean("local-model-json", false)
 
     override suspend fun produceNextMessage(conversation: VillagerConversation): String {
-        val payload = conversation.messages.joinToString("\n") { "${'$'}{it.role}: ${'$'}{it.content}" }
-        val response = client.post(endpoint) { setBody(payload) }
-        return response.bodyAsText()
+        return try {
+            val response = if (sendJson) {
+                val payload = buildJsonObject {
+                    put("messages", buildJsonArray {
+                        conversation.messages.forEach {
+                            add(buildJsonObject {
+                                put("role", it.role.role)
+                                put("content", it.content)
+                            })
+                        }
+                    })
+                }
+
+                client.post(endpoint) {
+                    contentType(ContentType.Application.Json)
+                    setBody(payload.toString())
+                }
+            } else {
+                val payload = conversation.messages.joinToString("\n") { "${'$'}{it.role}: ${'$'}{it.content}" }
+                client.post(endpoint) { setBody(payload) }
+            }
+
+            response.bodyAsText()
+        } catch (e: Exception) {
+            plugin.logger.log(Level.WARNING, "Failed to reach local model endpoint: ${'$'}{e.message}")
+            val message = Component.text("Failed to contact local model. Please try again later.")
+                .decorate(TextDecoration.ITALIC)
+            conversation.player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
+            throw e
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,8 @@ openai-model: "gpt-3.5-turbo"
 
 # URL for your locally hosted model's endpoint.
 local-model-url: "http://localhost:8000/"
+# Send conversation to the local model as JSON instead of plain text
+local-model-json: false
 
 # Log conversation messages to server console, useful for catching abuse
 log-conversations: true


### PR DESCRIPTION
## Summary
- support optional JSON payloads for local LLM calls
- catch networking failures when contacting a local model and warn the user

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686131c9bf38832c8d28450cf40a678d