### PR TITLE
Implement villager gossip system

### DIFF
--- a/src/main/kotlin/tj/horner/villagergpt/tasks/GossipManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/tasks/GossipManager.kt
@@ -13,7 +13,7 @@ class GossipManager(private val plugin: VillagerGPT) : BukkitRunnable() {
         val gossipLimit = plugin.config.getInt("gossip.max-entries", 30)
 
         plugin.server.worlds.forEach { world ->
-            val villagers = world.getEntitiesByClass(Villager::class.java)
+            val villagers = world.getEntitiesByClass(Villager::class.java).toList()
             for (i in villagers.indices) {
                 val villagerA = villagers[i]
                 for (j in i + 1 until villagers.size) {


### PR DESCRIPTION
## Summary
- store gossip in `ConversationMemory`
- periodically share gossip between villagers within range
- surface recent gossip when conversations start
- fix gossip manager iteration

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_686131cacd4c832ca1f09fa889e793c7