### PR TITLE
Use memory.max-messages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ VillagerGPT keeps a history of each villager's conversations in a small SQLite
 database. The location of this database and how many messages are stored can be
 changed in `config.yml` under the `memory` section.
 
-The maximum messages remembered per villager are configured with the
+The conversation history limit for each villager is configured with the
 `memory.max-messages` option.
 
 ### Gossip

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
@@ -70,7 +70,11 @@ class VillagerConversationManager(private val plugin: VillagerGPT) {
             val history = it.messages.drop(1)
 
             runBlocking {
-                plugin.memory.appendMessages(it.villager.uniqueId, history, plugin.config.getInt("max-stored-messages", 20))
+                plugin.memory.appendMessages(
+                    it.villager.uniqueId,
+                    history,
+                    plugin.config.getInt("memory.max-messages", 20)
+                )
             }
 
             it.ended = true


### PR DESCRIPTION
## Summary
- store history with memory.max-messages config
- clarify README about the `memory.max-messages` history limit

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68613db5b698832caee19e01231da15c