### PR TITLE
Add LocalMessageProducer cleanup

### DIFF
--- a/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
@@ -25,8 +25,9 @@ class VillagerGPT : SuspendingJavaPlugin() {
         private set
 
     val conversationManager = VillagerConversationManager(this)
+    private val messageProducer = createMessageProducer()
     val messagePipeline = MessageProcessorPipeline(
-        createMessageProducer(),
+        messageProducer,
         listOf(
             ActionProcessor(),
             TradeOfferProcessor(logger)
@@ -55,6 +56,10 @@ class VillagerGPT : SuspendingJavaPlugin() {
     override fun onDisable() {
         logger.info("Ending all conversations")
         conversationManager.endAllConversations()
+
+        if (messageProducer is LocalMessageProducer) {
+            messageProducer.close()
+        }
 
         memory.close()
 

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
@@ -58,4 +58,8 @@ class LocalMessageProducer(private val plugin: VillagerGPT, config: Configuratio
             throw e
         }
     }
+
+    fun close() {
+        client.close()
+    }
 }


### PR DESCRIPTION
## Summary
- close the `HttpClient` used by `LocalMessageProducer`
- keep a reference to the active message producer
- shut down the producer when the plugin disables

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68613db503f8832c98ff0a62730b2471