### PR TITLE
Use memory.max-messages config

### DIFF
--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerConversationManager.kt
@@ -71,7 +71,7 @@ class VillagerConversationManager(private val plugin: VillagerGPT) {
 
             runBlocking {
 
-                plugin.memory.appendMessages(it.villager.uniqueId, history, plugin.config.getInt("max-stored-messages", 20))
+                plugin.memory.appendMessages(it.villager.uniqueId, history, plugin.config.getInt("memory.max-messages", 20))
                 val summary = summarize(history)
                 plugin.memory.updateVillagerSummary(it.villager.uniqueId, summary)
 


### PR DESCRIPTION
## Summary
- update conversation manager to use the `memory.max-messages` config key

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686148d03da0832c80f5df4165886c40