### PR TITLE
Implement AutoCloseable for LocalMessageProducer

### DIFF
--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
@@ -21,7 +21,10 @@ import net.kyori.adventure.text.format.TextDecoration
 import java.util.logging.Level
 
 @OptIn(BetaOpenAI::class)
-class LocalMessageProducer(private val plugin: VillagerGPT, config: Configuration) : ConversationMessageProducer {
+class LocalMessageProducer(
+    private val plugin: VillagerGPT,
+    config: Configuration
+) : ConversationMessageProducer, AutoCloseable {
     private val client = HttpClient(Apache)
     private val endpoint = config.getString("local-model-url") ?: "http://localhost:8000/"
     private val sendJson = config.getBoolean("local-model-json", false)
@@ -59,7 +62,7 @@ class LocalMessageProducer(private val plugin: VillagerGPT, config: Configuratio
         }
     }
 
-    fun close() {
+    override fun close() {
         client.close()
     }
 }


### PR DESCRIPTION
## Summary
- implement `AutoCloseable` on `LocalMessageProducer`
- override `close()` so producer resources get cleaned up

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686148d0e2ac832cabe1ae056bd3b9b4