### PR TITLE
Use JDK 21 for Gradle builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI villagers are aware of various aspects of the game world, their reputation wi
 
 ## Requirements
 
-VillagerGPT requires **Java 17** or newer to build and run. Make sure a compatible JDK is installed and selected when compiling the plugin.
+VillagerGPT requires **Java 21** or newer to build and run. Make sure a compatible JDK is installed and selected when compiling the plugin.
 
 ## Example Conversations
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,9 @@ dependencies {
 
 def targetJavaVersion = 17
 java {
-    def javaVersion = JavaVersion.toVersion(targetJavaVersion)
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-    if (JavaVersion.current() < javaVersion) {
-        toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
-    }
+    sourceCompatibility = JavaVersion.toVersion(targetJavaVersion)
+    targetCompatibility = JavaVersion.toVersion(targetJavaVersion)
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -60,5 +57,9 @@ processResources {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions.jvmTarget = "17"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64


### PR DESCRIPTION
## Summary
- target Java 17 bytecode but compile using JDK 21
- configure Kotlin toolchain for JDK 21
- set Gradle to use JDK 21
- document JDK requirement update

## Testing
- `./gradlew test --no-daemon` *(fails: unresolved references during Kotlin compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68614daac480832c86eb23773208be17