### PR TITLE
Add environment-radius config

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ talking about. Control the sharing radius and how many entries are kept with the
 ### Environment
 
 VillagerGPT watches the surroundings during conversations. Adjust how far away
-entities are detected using `environment.radius` and how often checks occur with
+entities are detected using `environment.environment-radius` and how often checks occur with
 `environment.interval` in `config.yml`.
 
 ### Local Model

--- a/src/main/kotlin/tj/horner/villagergpt/tasks/EnvironmentWatcher.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/tasks/EnvironmentWatcher.kt
@@ -18,7 +18,7 @@ class EnvironmentWatcher(private val plugin: VillagerGPT) : BukkitRunnable() {
 
     private val state = mutableMapOf<VillagerConversation, EnvironmentState>()
 
-    private val radius: Double = plugin.config.getDouble("environment.radius", 5.0)
+    private val radius: Double = plugin.config.getDouble("environment.environment-radius", 5.0)
 
     override fun run() {
         val conversations = plugin.conversationManager.getActiveConversations()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,7 +38,7 @@ gossip:
 # Watch the environment during conversations and narrate changes
 environment:
   # Distance in blocks in which to watch for nearby mobs or players
-  radius: 5
+  environment-radius: 5
   # How often to check the environment, in ticks
   interval: 20
 


### PR DESCRIPTION
## Summary
- document environment configuration in README
- allow configuring radius via `environment.environment-radius`

## Testing
- `./gradlew test --no-daemon` *(fails: Unresolved reference: serialization)*

------
https://chatgpt.com/codex/tasks/task_e_68614da92064832ca34e0490c912c590