### PR TITLE
Handle LocalMessageProducer shutdown

### DIFF
--- a/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/VillagerGPT.kt
@@ -61,7 +61,7 @@ class VillagerGPT : SuspendingJavaPlugin() {
         logger.info("Ending all conversations")
         conversationManager.endAllConversations()
 
-        if (messageProducer is LocalMessageProducer) {
+        if (messageProducer is AutoCloseable) {
             messageProducer.close()
         }
 

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/LocalMessageProducer.kt
@@ -62,6 +62,9 @@ class LocalMessageProducer(
         }
     }
 
+    /**
+     * Release HTTP resources used by this producer.
+     */
     override fun close() {
         client.close()
     }


### PR DESCRIPTION
## Summary
- document shutdown behavior in `LocalMessageProducer.close`
- close any `AutoCloseable` message producer when disabling the plugin

## Testing
- `gradle test --no-daemon` *(fails: Could not determine the dependencies of task ':compileKotlin'. Cannot find a Java installation on your machine)*

------
https://chatgpt.com/codex/tasks/task_e_68614da834a8832cb091de146dd8a620