### PR TITLE
Remove unused Bukkit plugin imports

### DIFF
--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/processors/TradeOfferProcessor.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/processors/TradeOfferProcessor.kt
@@ -9,8 +9,6 @@ import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.MerchantRecipe
-import org.bukkit.plugin.Plugin
-import org.bukkit.plugin.java.JavaPlugin
 import tj.horner.villagergpt.conversation.VillagerConversation
 import tj.horner.villagergpt.conversation.formatting.MessageFormatter
 import tj.horner.villagergpt.conversation.pipeline.ConversationMessageAction


### PR DESCRIPTION
## Summary
- remove `Plugin` and `JavaPlugin` imports from `TradeOfferProcessor`

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation matching requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68614da6a98c832cb24f6d7042e75d9b