### PR TITLE
Add guard defense task flow with persistent threat signals

### DIFF
--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/VillagerLifePlugin.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/VillagerLifePlugin.java
@@ -8,6 +8,7 @@ import io.github.enpici.villager.life.command.VillagerLifeCommand;
 import io.github.enpici.villager.life.integration.CitizensAdapter;
 import io.github.enpici.villager.life.integration.CitizensGateway;
 import io.github.enpici.villager.life.integration.VillagerLifeContextProvider;
+import io.github.enpici.villager.life.listener.ThreatSignalListener;
 import io.github.enpici.villager.life.scheduler.SimulationScheduler;
 import io.github.enpici.villager.life.village.VillageManager;
 import org.bukkit.plugin.ServicePriority;
@@ -54,6 +55,8 @@ public final class VillagerLifePlugin extends JavaPlugin {
             pluginCommand.setExecutor(command);
             pluginCommand.setTabCompleter(command);
         }
+
+        getServer().getPluginManager().registerEvents(new ThreatSignalListener(villageManager, agentManager), this);
 
         simulationScheduler.start();
         getLogger().info("VillagerLife enabled. MVP skeleton activo.");

--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/ai/DecisionEngine.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/ai/DecisionEngine.java
@@ -11,6 +11,17 @@ import org.bukkit.Bukkit;
 public class DecisionEngine {
 
     public Task decide(Agent agent, VillageAI village) {
+        if (agent.role() == AgentRole.GUARD) {
+            var villager = Bukkit.getServer() != null ? agent.resolveVillager() : null;
+            if (village.threatDetected()) {
+                return new InterceptThreatTask();
+            }
+            if (villager != null && villager.getLocation().distanceSquared(village.center()) > 36) {
+                return new ReturnToPostTask();
+            }
+            return new PatrolTask();
+        }
+
         double eat = agent.needLevel(NeedType.HUNGER) * 1.4;
         double sleep = agent.needLevel(NeedType.ENERGY) * 1.2;
         double flee = village.threatDetected() ? 95 : agent.needLevel(NeedType.SAFETY);
@@ -26,7 +37,6 @@ public class DecisionEngine {
         return switch (agent.role()) {
             case FARMER -> new HarvestTask();
             case BUILDER -> !village.pendingMaterials().isEmpty() ? new DepositItemsTask() : new WanderTask();
-            case GUARD -> new WanderTask();
             default -> new WanderTask();
         };
     }

--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/event/WorldThreatEvent.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/event/WorldThreatEvent.java
@@ -1,0 +1,35 @@
+package io.github.enpici.villager.life.event;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class WorldThreatEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final String source;
+    private final Location location;
+
+    public WorldThreatEvent(String source, Location location) {
+        this.source = source;
+        this.location = location;
+    }
+
+    public String source() {
+        return source;
+    }
+
+    public Location location() {
+        return location;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/listener/ThreatSignalListener.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/listener/ThreatSignalListener.java
@@ -1,0 +1,39 @@
+package io.github.enpici.villager.life.listener;
+
+import io.github.enpici.villager.life.agent.Agent;
+import io.github.enpici.villager.life.agent.AgentManager;
+import io.github.enpici.villager.life.event.AgentThreatDetectedEvent;
+import io.github.enpici.villager.life.event.WorldThreatEvent;
+import io.github.enpici.villager.life.village.VillageManager;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ThreatSignalListener implements Listener {
+
+    private static final long THREAT_SIGNAL_TTL = 300L;
+    private final VillageManager villageManager;
+    private final AgentManager agentManager;
+
+    public ThreatSignalListener(VillageManager villageManager, AgentManager agentManager) {
+        this.villageManager = villageManager;
+        this.agentManager = agentManager;
+    }
+
+    @EventHandler
+    public void onWorldThreat(WorldThreatEvent event) {
+        villageManager.currentVillage().ifPresent(village -> {
+            String source = "event:" + event.source();
+            village.registerThreatSignal(source, event.location(), THREAT_SIGNAL_TTL);
+
+            Agent guard = agentManager.all().stream()
+                    .filter(agent -> agent.role() == io.github.enpici.villager.life.role.AgentRole.GUARD)
+                    .findFirst()
+                    .orElse(null);
+            if (guard != null) {
+                guard.setLastEvent("defense:threat:" + event.source());
+                Bukkit.getPluginManager().callEvent(new AgentThreatDetectedEvent(guard, event.source()));
+            }
+        });
+    }
+}

--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/task/impl/InterceptThreatTask.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/task/impl/InterceptThreatTask.java
@@ -1,0 +1,41 @@
+package io.github.enpici.villager.life.task.impl;
+
+import io.github.enpici.villager.life.agent.Agent;
+import io.github.enpici.villager.life.task.BaseTask;
+import io.github.enpici.villager.life.task.TaskStatus;
+import io.github.enpici.villager.life.village.VillageAI;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Villager;
+
+public class InterceptThreatTask extends BaseTask {
+
+    public InterceptThreatTask() {
+        super("intercept_threat", 100L);
+    }
+
+    @Override
+    public boolean canStart(Agent agent, VillageAI villageAI) {
+        return villageAI.threatDetected() && villageAI.activeThreatLocation().isPresent();
+    }
+
+    @Override
+    protected TaskStatus onTick(Agent agent, VillageAI villageAI) {
+        Villager villager = agent.resolveVillager();
+        if (villager == null || !villager.isValid()) {
+            return TaskStatus.FAILED;
+        }
+
+        Location threat = villageAI.activeThreatLocation().orElse(villageAI.center());
+        villager.getPathfinder().moveTo(threat);
+        agent.setLastEvent("defense:intercepting:" + threat.getBlockX() + "," + threat.getBlockZ());
+
+        if (villager.getLocation().distanceSquared(threat) <= 9) {
+            villageAI.clearThreatSignal("event:world-threat");
+            Bukkit.getPluginManager().callEvent(new io.github.enpici.villager.life.event.AgentThreatDetectedEvent(agent, "guard-intercept"));
+            return TaskStatus.SUCCESS;
+        }
+
+        return TaskStatus.RUNNING;
+    }
+}

--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/task/impl/PatrolTask.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/task/impl/PatrolTask.java
@@ -1,0 +1,35 @@
+package io.github.enpici.villager.life.task.impl;
+
+import io.github.enpici.villager.life.agent.Agent;
+import io.github.enpici.villager.life.task.BaseTask;
+import io.github.enpici.villager.life.task.TaskStatus;
+import io.github.enpici.villager.life.village.VillageAI;
+import org.bukkit.Location;
+import org.bukkit.entity.Villager;
+
+public class PatrolTask extends BaseTask {
+
+    public PatrolTask() {
+        super("patrol", 120L);
+    }
+
+    @Override
+    public boolean canStart(Agent agent, VillageAI villageAI) {
+        return villageAI.center().getWorld() != null;
+    }
+
+    @Override
+    protected TaskStatus onTick(Agent agent, VillageAI villageAI) {
+        Villager villager = agent.resolveVillager();
+        if (villager == null || !villager.isValid()) {
+            return TaskStatus.FAILED;
+        }
+
+        Location center = villageAI.center();
+        double angle = (org.bukkit.Bukkit.getCurrentTick() % 360) * Math.PI / 180.0;
+        Location perimeterPoint = center.clone().add(Math.cos(angle) * 8.0, 0, Math.sin(angle) * 8.0);
+        villager.getPathfinder().moveTo(perimeterPoint);
+
+        return TaskStatus.SUCCESS;
+    }
+}

--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/task/impl/ReturnToPostTask.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/task/impl/ReturnToPostTask.java
@@ -1,0 +1,35 @@
+package io.github.enpici.villager.life.task.impl;
+
+import io.github.enpici.villager.life.agent.Agent;
+import io.github.enpici.villager.life.task.BaseTask;
+import io.github.enpici.villager.life.task.TaskStatus;
+import io.github.enpici.villager.life.village.VillageAI;
+import org.bukkit.entity.Villager;
+
+public class ReturnToPostTask extends BaseTask {
+
+    public ReturnToPostTask() {
+        super("return_to_post", 120L);
+    }
+
+    @Override
+    public boolean canStart(Agent agent, VillageAI villageAI) {
+        return villageAI.center().getWorld() != null;
+    }
+
+    @Override
+    protected TaskStatus onTick(Agent agent, VillageAI villageAI) {
+        Villager villager = agent.resolveVillager();
+        if (villager == null || !villager.isValid()) {
+            return TaskStatus.FAILED;
+        }
+        var center = villageAI.center();
+        villager.getPathfinder().moveTo(center);
+
+        if (villager.getLocation().distanceSquared(center) <= 4) {
+            agent.setLastEvent("defense:post-secured");
+            return TaskStatus.SUCCESS;
+        }
+        return TaskStatus.RUNNING;
+    }
+}

--- a/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/village/VillageAI.java
+++ b/villagerlife-plugin/src/main/java/io/github/enpici/villager/life/village/VillageAI.java
@@ -14,8 +14,10 @@ import org.bukkit.entity.Villager;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +43,7 @@ public class VillageAI {
     private long lastThreatTick = -10_000L;
     private long lastReproductionTick = -10_000L;
     private Map<Material, Integer> pendingMaterials = Map.of();
+    private final Map<String, ThreatSignal> activeThreatSignals = new ConcurrentHashMap<>();
 
     public VillageAI(UUID id, String name, Location center, AgentManager agentManager, BlueprintService blueprintService) {
         this.id = id;
@@ -62,7 +65,17 @@ public class VillageAI {
     public int foodStock() { return foodStock; }
     public int bedCount() { return bedCount; }
     public int populationTarget() { return populationTarget; }
-    public boolean threatDetected() { return Bukkit.getCurrentTick() - lastThreatTick < 200L; }
+    public boolean threatDetected() {
+        pruneThreatSignals();
+        return !activeThreatSignals.isEmpty() || currentTick() - lastThreatTick < 200L;
+    }
+
+    public Optional<Location> activeThreatLocation() {
+        pruneThreatSignals();
+        return activeThreatSignals.values().stream()
+                .findFirst()
+                .map(signal -> signal.location().clone());
+    }
 
     public synchronized void addFoodStock(int amount) {
         foodStock = Math.max(0, foodStock + amount);
@@ -164,15 +177,43 @@ public class VillageAI {
         if (foodStock < Math.max(8, population() * 2)) return false;
         if (bedCount < population() + 1) return false;
         if (threatDetected()) return false;
-        return Bukkit.getCurrentTick() - lastReproductionTick > 1_200L;
+        return currentTick() - lastReproductionTick > 1_200L;
     }
 
     public void markReproduction() {
-        lastReproductionTick = Bukkit.getCurrentTick();
+        lastReproductionTick = currentTick();
     }
 
     public void markThreat() {
-        lastThreatTick = Bukkit.getCurrentTick();
+        lastThreatTick = currentTick();
+    }
+
+    public void registerThreatSignal(String source, Location location, long ttlTicks) {
+        if (source == null || source.isBlank()) {
+            return;
+        }
+        long now = currentTick();
+        long expiresAt = now + Math.max(1L, ttlTicks);
+        Location threatLocation = location != null ? location.clone() : center.clone();
+        activeThreatSignals.put(source, new ThreatSignal(threatLocation, expiresAt));
+        lastThreatTick = now;
+    }
+
+    public void clearThreatSignal(String source) {
+        if (source == null || source.isBlank()) {
+            return;
+        }
+        activeThreatSignals.remove(source);
+    }
+
+    private void pruneThreatSignals() {
+        long now = currentTick();
+        Iterator<Map.Entry<String, ThreatSignal>> iterator = activeThreatSignals.entrySet().iterator();
+        while (iterator.hasNext()) {
+            if (iterator.next().getValue().expiresAtTick() <= now) {
+                iterator.remove();
+            }
+        }
     }
 
     public Villager tryReproduce() {
@@ -242,4 +283,10 @@ public class VillageAI {
     }
 
     public record MaterialRequest(Material material, int amount) {}
+
+    private long currentTick() {
+        return Bukkit.getServer() != null ? Bukkit.getCurrentTick() : 0L;
+    }
+
+    private record ThreatSignal(Location location, long expiresAtTick) {}
 }

--- a/villagerlife-plugin/src/test/java/io/github/enpici/villager/life/ai/GuardDecisionEngineStateTransitionTest.java
+++ b/villagerlife-plugin/src/test/java/io/github/enpici/villager/life/ai/GuardDecisionEngineStateTransitionTest.java
@@ -1,0 +1,42 @@
+package io.github.enpici.villager.life.ai;
+
+import io.github.enpici.villager.life.agent.Agent;
+import io.github.enpici.villager.life.agent.AgentManager;
+import io.github.enpici.villager.life.blueprint.BlueprintService;
+import io.github.enpici.villager.life.role.AgentRole;
+import io.github.enpici.villager.life.task.Task;
+import io.github.enpici.villager.life.task.TaskStatus;
+import io.github.enpici.villager.life.task.impl.InterceptThreatTask;
+import io.github.enpici.villager.life.task.impl.PatrolTask;
+import io.github.enpici.villager.life.village.VillageAI;
+import org.bukkit.Location;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GuardDecisionEngineStateTransitionTest {
+
+    private final DecisionEngine decisionEngine = new DecisionEngine();
+
+    @Test
+    void guardTransitionsPatrolToInterceptToIdleState() {
+        VillageAI village = new VillageAI(UUID.randomUUID(), "test", new Location(null, 0, 64, 0), new AgentManager(null), (BlueprintService) null);
+        Agent guard = new Agent(UUID.randomUUID(), AgentRole.GUARD);
+
+        Task patrol = decisionEngine.decide(guard, village);
+        assertInstanceOf(PatrolTask.class, patrol);
+
+        village.registerThreatSignal("world-threat", village.center(), 200L);
+        Task intercept = decisionEngine.decide(guard, village);
+        assertInstanceOf(InterceptThreatTask.class, intercept);
+
+        guard.assignTask(intercept);
+        guard.clearTask(TaskStatus.SUCCESS);
+        assertNull(guard.activeTask(), "sin tarea activa, el agente está en idle");
+        assertEquals("task:success", guard.lastEvent());
+    }
+}


### PR DESCRIPTION
### Motivation

- Mejorar el comportamiento de los agentes con rol `GUARD` para que no se limiten a `Wander` y puedan responder a amenazas detectadas por el mundo. 
- Permitir a la AI del pueblo recibir señales de amenaza persistentes (con TTL y ubicación) para tomar decisiones más fiables que un flag temporal. 

### Description

- Añadidas tareas específicas en `task/impl`: `PatrolTask`, `InterceptThreatTask` y `ReturnToPostTask` para patrulla perimetral, intercepción de amenaza y regreso al puesto. 
- Modificada la lógica de `DecisionEngine.decide()` para que `GUARD` priorice: detección de amenaza activa → `InterceptThreatTask`, si está desplazado → `ReturnToPostTask`, en caso contrario → `PatrolTask`. 
- Extendida `VillageAI` con almacenamiento de señales de amenaza (`activeThreatSignals`) con TTL, resolución de ubicación de amenaza y manejo seguro del tick (`currentTick()` para entornos sin servidor Bukkit). 
- Añadido `WorldThreatEvent` y `ThreatSignalListener` para inyectar eventos del mundo hacia `VillageAI`, registro del listener en `VillagerLifePlugin`, y emisión de `AgentThreatDetectedEvent` junto con `lastEvent` contextual para integración con VillagerGPT. 
- Añadido test de estado `GuardDecisionEngineStateTransitionTest` que verifica la transición `patrol -> intercept -> idle` a nivel de decisión/estado.

### Testing

- Se instaló la API localmente con `mvn -pl villager-api install -DskipTests` para resolver dependencias locales y luego se ejecutó `mvn -N install` para el parent; ambos comandos tuvieron éxito. 
- Se ejecutó el test específico con `mvn -pl villagerlife-plugin test -Dtest=GuardDecisionEngineStateTransitionTest` y el test `GuardDecisionEngineStateTransitionTest` pasó correctamente. 
- Se ejecutó la suite de tests del módulo con `mvn -pl villagerlife-plugin test` y la ejecución terminó en `BUILD SUCCESS` (tests totales: 6, skipped: 4, failures/errors: 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44b762a20832cb0a4fcfe2b280bd4)